### PR TITLE
feat: updated options for 'jsyaml.dump'

### DIFF
--- a/features/cms/utils/customDirectiveUtils.ts
+++ b/features/cms/utils/customDirectiveUtils.ts
@@ -12,7 +12,15 @@ interface Options {
 }
 
 export const renderCustomDirective = (name: string, object: object) =>
-  `:::${name}\n` + (object ? jsyaml.dump(object) : "") + ":::";
+  `:::${name}\n` +
+  (object
+    ? jsyaml.dump(object, {
+        forceQuotes: true,
+        quotingType: '"',
+        noCompatMode: true,
+      })
+    : "") +
+  ":::";
 
 export const customDirectivePattern = (name: string) =>
   new RegExp(`^:::${name}\\n([\\s\\S]+?\\n)?:::$`, "m");


### PR DESCRIPTION
## Description

updated options for 'jsyaml.dump':
- main:
   - forceQuotes: Wraps all strings in quotes (fixes the YAML processing bug on the landing page)
- Additionally added:
   -  quotingType: set double quotes
   - noCompatMode: disabled compatibility with older YAML versions

