### PR TITLE
feat: eth stake widget FAQ collection and `questionId` field to faqWidget preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ next-env.d.ts
 # local content for local development
 /lido-landing
 /widget-frontend-template
+/ethereum-staking-widget
 
 #ide
 .vscode

--- a/features/cms/initialize/collections/ethereumStakingWidget/ethereumStakingWidget.ts
+++ b/features/cms/initialize/collections/ethereumStakingWidget/ethereumStakingWidget.ts
@@ -1,0 +1,9 @@
+import type { CmsCollection } from "netlify-cms-core";
+
+import { faq } from "./files/faq";
+
+export const ethereumStakingWidget: CmsCollection = {
+  name: "ethereum-staking-widget",
+  label: "Ethereum staking widget",
+  files: [faq],
+};

--- a/features/cms/initialize/collections/ethereumStakingWidget/files/faq.ts
+++ b/features/cms/initialize/collections/ethereumStakingWidget/files/faq.ts
@@ -27,6 +27,11 @@ export const faq: CmsCollectionFile = {
               widget: "string",
             },
             {
+              name: "questionId",
+              label: "Question Id",
+              widget: "string",
+            },
+            {
               name: "answer",
               label: "Answer",
               widget: "markdown",

--- a/features/cms/initialize/collections/ethereumStakingWidget/files/faq.ts
+++ b/features/cms/initialize/collections/ethereumStakingWidget/files/faq.ts
@@ -1,0 +1,42 @@
+import type { CmsCollectionFile } from "netlify-cms-core";
+
+export const faq: CmsCollectionFile = {
+  name: "faq-on-widget",
+  label: "FAQ on widget",
+  description: "FAQ on widgets pages",
+  file: "ethereum-staking-widget/faq.md",
+  fields: [
+    {
+      widget: "list",
+      name: "pages",
+      label: "Pages",
+      fields: [
+        {
+          widget: "string",
+          name: "identification",
+          label: "Identification",
+        },
+        {
+          widget: "list",
+          name: "faq",
+          label: "FAQ",
+          fields: [
+            {
+              name: "question",
+              label: "Question",
+              widget: "string",
+            },
+            {
+              name: "answer",
+              label: "Answer",
+              widget: "markdown",
+              editor_components: [],
+              modes: ["rich_text"],
+              buttons: ["link", "bulleted-list", "bold"],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/features/cms/initialize/collections/ethereumStakingWidget/files/faq.ts
+++ b/features/cms/initialize/collections/ethereumStakingWidget/files/faq.ts
@@ -1,7 +1,7 @@
 import type { CmsCollectionFile } from "netlify-cms-core";
 
 export const faq: CmsCollectionFile = {
-  name: "faq-on-widget",
+  name: "faq-on-ethereum-staking-widget",
   label: "FAQ on widget",
   description: "FAQ on widgets pages",
   file: "ethereum-staking-widget/faq.md",

--- a/features/cms/initialize/collections/frontendTemplate/files/faq.ts
+++ b/features/cms/initialize/collections/frontendTemplate/files/faq.ts
@@ -1,7 +1,7 @@
 import type { CmsCollectionFile } from "netlify-cms-core";
 
 export const faq: CmsCollectionFile = {
-  name: "faq-on-widget-frontend-template",
+  name: "faq-on-frontend-template-widget",
   label: "FAQ on widget",
   description: "FAQ on widgets pages",
   file: "widget-frontend-template/faq.md",

--- a/features/cms/initialize/collections/frontendTemplate/files/faq.ts
+++ b/features/cms/initialize/collections/frontendTemplate/files/faq.ts
@@ -1,7 +1,7 @@
 import type { CmsCollectionFile } from "netlify-cms-core";
 
 export const faq: CmsCollectionFile = {
-  name: "faq-on-widget",
+  name: "faq-on-widget-frontend-template",
   label: "FAQ on widget",
   description: "FAQ on widgets pages",
   file: "widget-frontend-template/faq.md",

--- a/features/cms/initialize/collections/frontendTemplate/files/faq.ts
+++ b/features/cms/initialize/collections/frontendTemplate/files/faq.ts
@@ -27,6 +27,11 @@ export const faq: CmsCollectionFile = {
               widget: "string",
             },
             {
+              name: "questionId",
+              label: "Question Id",
+              widget: "string",
+            },
+            {
               name: "answer",
               label: "Answer",
               widget: "markdown",

--- a/features/cms/initialize/collections/index.ts
+++ b/features/cms/initialize/collections/index.ts
@@ -1,5 +1,6 @@
 export * from "./lidoLanding/lidoLanding";
 export * from "./ecosystemProject/ecosystemProjects";
 export * from "./ecosystemConfig/ecosystemConfig";
+export * from "./ethereumStakingWidget/ethereumStakingWidget";
 export * from "./validatorsProjects/validatorsProjects";
 export * from "./frontendTemplate/frontendTemplate";

--- a/features/cms/initialize/initialize.ts
+++ b/features/cms/initialize/initialize.ts
@@ -6,6 +6,7 @@ import {
   ecosystemConfig,
   validatorsProjects,
   frontendTemplate,
+  ethereumStakingWidget,
 } from "./collections";
 
 const { publicRuntimeConfig } = getConfig();
@@ -29,6 +30,7 @@ export const initializeCMS = () => {
         ecosystemConfig,
         validatorsProjects,
         frontendTemplate,
+        ethereumStakingWidget,
       ],
     },
   });

--- a/features/cms/previews/faqWidgets/faqWidgets.tsx
+++ b/features/cms/previews/faqWidgets/faqWidgets.tsx
@@ -1,6 +1,7 @@
 import { PreviewTemplateComponentProps } from "netlify-cms-core";
 
-import { faq } from "features/cms/initialize/collections/frontendTemplate/files/faq";
+import { faq as faqFrontendTemplate } from "features/cms/initialize/collections/frontendTemplate/files/faq";
+import { faq as faqEthereumStakingWidget } from "features/cms/initialize/collections/ethereumStakingWidget/files/faq";
 
 import { withStyledComponentsRendered } from "features/cms/utils/StyleInjector";
 
@@ -40,7 +41,11 @@ export const FaqWidgetsPreview = ({ entry }: PreviewTemplateComponentProps) => {
 
 export const registerFaqWidgetsPreviewTemplate = () => {
   CMS.registerPreviewTemplate(
-    faq.name,
+    faqFrontendTemplate.name,
+    withStyledComponentsRendered(FaqWidgetsPreview)
+  );
+  CMS.registerPreviewTemplate(
+    faqEthereumStakingWidget.name,
     withStyledComponentsRendered(FaqWidgetsPreview)
   );
 };

--- a/features/cms/previews/faqWidgets/faqWidgets.tsx
+++ b/features/cms/previews/faqWidgets/faqWidgets.tsx
@@ -11,6 +11,7 @@ type Data = {
   pages: {
     identification?: string;
     faq?: {
+      questionId: string;
       question: string;
       answer: string;
     }[];
@@ -27,8 +28,9 @@ export const FaqWidgetsPreview = ({ entry }: PreviewTemplateComponentProps) => {
           <Text>
             <Bold>Page identification:</Bold> {pages.identification}
           </Text>
-          {pages.faq?.map(({ question, answer }) => (
+          {pages.faq?.map(({ questionId, question, answer }) => (
             <Box key={question}>
+              <Text>question ID: {questionId}</Text>
               <Text>question: {question}</Text>
               <Text>answer: {answer}</Text>
             </Box>


### PR DESCRIPTION
## Description

1. Added FAQ for [Eth stake widget](https://stake.lido.fi/).
2. Added `questionId` field for question block (any widget).

## Demo

<img width="1507" alt="image" src="https://github.com/lidofinance/lido-cms/assets/9885789/23b92d21-7c47-40a3-9006-0945261468c5">

## Review notes

skip

## Testing notes

skip
